### PR TITLE
Wordpress 7.0 Compatibility

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -7,6 +7,7 @@ jobs:
   master:
     name: Push to master
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -7,8 +7,18 @@ jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@stable
+      with:
+        fetch-depth: 0
+    - name: Verify release tag is reachable from master
+      run: |
+        git fetch --no-tags --depth=50 origin master:refs/remotes/origin/master
+        if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/master; then
+          echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from master. Refusing to deploy."
+          exit 1
+        fi
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-asset-update@stable
       env:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Astra Hooks #
 **Contributors:** brainstormforce  
 **Tags:** astra theme, customizer hooks, astra hooks  
-**Tested up to:** 6.9  
+**Tested up to:** 7.0  
 **Stable tag:** 1.0.2  
 **Requires at least:** 4.4  
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
         "wp-coding-standards/wpcs": "dev-master",
         "phpcompatibility/phpcompatibility-wp": "*"
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "scripts": {
         "format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
         "lint": "phpcs --standard=phpcs.xml.dist --report-summary --report-source"

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Astra Hooks ===
 Contributors: brainstormforce
 Tags: astra theme, customizer hooks, astra hooks
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.0.2
 Requires at least: 4.4
 


### PR DESCRIPTION
## WordPress 7.0 Compatibility
- Tested with 7.0 and it's working fine (bumped `Tested up to` in `README.md` and `readme.txt`).

## Deploy workflow hardening (ports [astra-sites#886](https://github.com/brainstormforce/astra-sites/pull/886))
- Added `environment: production` to the deploy jobs in `push-asset-readme-update.yml` and `push-to-deploy.yml` so org-level `SVN_*` secrets are only reachable from workflows running on `master` + tags (via a scoped `production` GitHub Environment restricted to those refs).
- Added a guard in `push-to-deploy.yml` that refuses to deploy a tag not reachable from `master`.

## CI fix
- Defined `config.allow-plugins` in `composer.json` for `dealerdirect/phpcodesniffer-composer-installer` — the phpcs workflow was failing on `composer install` under Composer 2.x's allow-plugins gate.