### PR TITLE
ci: fix asset/readme update workflow (IGNORE_OTHER_FILES)

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -15,3 +15,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        IGNORE_OTHER_FILES: true

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -24,3 +24,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        IGNORE_OTHER_FILES: true

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -24,4 +24,3 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        IGNORE_OTHER_FILES: true


### PR DESCRIPTION
The **Plugin asset/readme update** workflow fails on push to master with `🛑 Other files have been modified; changes not deployed`.

## Cause
The `10up/action-wordpress-plugin-asset-update` action, in default mode, copies the whole repo into SVN `trunk/` and aborts if anything other than `readme.txt` differs. SVN `trunk/` has drift vs. the repo (gitignored build files, `package-lock.json` in `.distignore`), so the guard always trips.

## Fix
Set `IGNORE_OTHER_FILES: true` so the action copies **only** `readme.txt` + `.wordpress-org` assets and ignores unrelated trunk files. Code still ships via `push-to-deploy.yml` on tags.